### PR TITLE
Change module type to silverstripe-vendormodule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dia-nz/silverstripe-date-range-field",
     "description": "A date range field and filter for SilverStripe",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "authors": [
         {


### PR DESCRIPTION
This change will ensure the module is installed within the `vendor` folder instead of the root.